### PR TITLE
Switch to Ktor

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,3 +21,9 @@ jobs:
       with:
         gradle-version: current
         arguments: build
+
+    - name: Test
+      uses: gradle/gradle-build-action@v2
+      with:
+        gradle-version: current
+        arguments: test

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ RecaptchaClient.createV3("your secret key...", true)
 
 ## Uses:
 * [Kotlin-coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-* [Fuel](https://github.com/kittinunf/Fuel) (http client)
+* [Ktor](https://ktor.io/docs/welcome.html) (http client)
 * [Gson](https://github.com/google/gson)
 
 ## License

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,11 @@ dependencies {
     implementation('com.github.kittinunf.fuel:fuel:2.3.1')
 
 
+    def ktor_version = "2.2.4"
+    implementation("io.ktor:ktor-client-core:$ktor_version")
+    implementation("io.ktor:ktor-client-cio:$ktor_version")
+    testImplementation("io.ktor:ktor-client-mock:$ktor_version")
+
 //    Json parser
     implementation('com.google.code.gson:gson:2.10.1')
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,15 +15,20 @@ dependencies {
 //    Http client used in this project
     implementation('com.github.kittinunf.fuel:fuel:2.3.1')
 
-
     def ktor_version = "2.2.4"
     implementation("io.ktor:ktor-client-core:$ktor_version")
     implementation("io.ktor:ktor-client-cio:$ktor_version")
+
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.0")
     testImplementation("io.ktor:ktor-client-mock:$ktor_version")
 
 //    Json parser
     implementation('com.google.code.gson:gson:2.10.1')
 
+}
+
+test {
+    useJUnitPlatform()
 }
 
 compileKotlin {

--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,6 @@ repositories {
 dependencies {
     implementation('org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4')
 
-//    Http client used in this project
-    implementation('com.github.kittinunf.fuel:fuel:2.3.1')
-
     def ktor_version = "2.2.4"
     implementation("io.ktor:ktor-client-core:$ktor_version")
     implementation("io.ktor:ktor-client-cio:$ktor_version")

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,1 @@
 rootProject.name = 'recaptcha-v3-kotlin-client'
-

--- a/src/main/kotlin/com/wusatosi/recaptcha/Exceptions.kt
+++ b/src/main/kotlin/com/wusatosi/recaptcha/Exceptions.kt
@@ -1,6 +1,5 @@
 package com.wusatosi.recaptcha
 
-import com.github.kittinunf.fuel.core.Response
 import com.google.gson.JsonParseException
 import com.wusatosi.recaptcha.internal.issue_address
 import java.io.IOException

--- a/src/main/kotlin/com/wusatosi/recaptcha/RecaptchaClient.kt
+++ b/src/main/kotlin/com/wusatosi/recaptcha/RecaptchaClient.kt
@@ -4,8 +4,12 @@ import com.wusatosi.recaptcha.internal.UniversalRecaptchaClientImpl
 import com.wusatosi.recaptcha.internal.checkURLCompatibility
 import com.wusatosi.recaptcha.v2.RecaptchaV2Client
 import com.wusatosi.recaptcha.v3.RecaptchaV3Client
+import io.ktor.client.*
+import io.ktor.client.engine.*
+import io.ktor.client.engine.cio.*
+import java.io.Closeable
 
-interface RecaptchaClient {
+interface RecaptchaClient : Closeable {
 
     @Throws(RecaptchaError::class)
     suspend fun verify(token: String): Boolean
@@ -15,7 +19,8 @@ interface RecaptchaClient {
         fun createUniversal(
             secretKey: String,
             defaultScoreThreshold: Double = 0.5,
-            useRecaptchaDotNetEndPoint: Boolean = false
+            useRecaptchaDotNetEndPoint: Boolean = false,
+            engine: HttpClientEngine = CIO.create()
         ): RecaptchaClient {
             if (!checkURLCompatibility(secretKey))
                 throw InvalidSiteKeyException
@@ -23,18 +28,24 @@ interface RecaptchaClient {
             return UniversalRecaptchaClientImpl(
                 secretKey,
                 defaultScoreThreshold,
-                useRecaptchaDotNetEndPoint
+                useRecaptchaDotNetEndPoint,
+                engine
             )
         }
 
-        fun createV2(siteKey: String, useRecaptchaDotNetEndpoint: Boolean = false) =
-            RecaptchaV2Client.create(siteKey, useRecaptchaDotNetEndpoint)
+        fun createV2(
+            siteKey: String,
+            useRecaptchaDotNetEndpoint: Boolean = false,
+            engine: HttpClientEngine = CIO.create()
+        ) =
+            RecaptchaV2Client.create(siteKey, useRecaptchaDotNetEndpoint, engine)
 
         fun createV3(
             siteKey: String,
             defaultScoreThreshold: Double = 0.5,
-            useRecaptchaDotNetEndpoint: Boolean = false
-        ) = RecaptchaV3Client.create(siteKey, defaultScoreThreshold, useRecaptchaDotNetEndpoint)
+            useRecaptchaDotNetEndpoint: Boolean = false,
+            engine: HttpClientEngine = CIO.create()
+        ) = RecaptchaV3Client.create(siteKey, defaultScoreThreshold, useRecaptchaDotNetEndpoint, engine)
 
     }
 

--- a/src/main/kotlin/com/wusatosi/recaptcha/internal/RecaptchaClientBase.kt
+++ b/src/main/kotlin/com/wusatosi/recaptcha/internal/RecaptchaClientBase.kt
@@ -22,9 +22,6 @@ internal abstract class RecaptchaClientBase(
     private val validateHost = if (useRecaptchaDotNetEndPoint) "www.recaptcha.net" else "www.google.com"
     private val path = "/recaptcha/api/siteverify"
 
-    // TODO: remove me after switch to ktor
-    protected val validateURL = "https://$validateHost/$path?secret=$secretKey&response="
-
     protected suspend fun transact(token: String): JsonObject {
         val response =
             try {

--- a/src/main/kotlin/com/wusatosi/recaptcha/internal/RecaptchaClientBase.kt
+++ b/src/main/kotlin/com/wusatosi/recaptcha/internal/RecaptchaClientBase.kt
@@ -1,0 +1,66 @@
+package com.wusatosi.recaptcha.internal
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.google.gson.JsonSyntaxException
+import com.wusatosi.recaptcha.*
+import io.ktor.client.*
+import io.ktor.client.engine.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.serialization.gson.*
+import java.io.IOException
+
+internal abstract class RecaptchaClientBase(
+    private val secretKey: String,
+    useRecaptchaDotNetEndPoint: Boolean,
+    engine: HttpClientEngine
+) : RecaptchaClient {
+
+    protected val client: HttpClient = HttpClient(engine) {
+        install(ContentNegotiation) {
+            gson()
+        }
+    }
+    private val validateHost = if (useRecaptchaDotNetEndPoint) "www.recaptcha.net" else "www.google.com"
+    private val path = "/recaptcha/api/siteverify"
+
+    // TODO: remove me after switch to ktor
+    protected val validateURL = "https://$validateHost/$path?secret=$secretKey&response="
+
+    protected suspend fun transact(token: String): JsonObject {
+        val response =
+            try {
+                client.post {
+                    url {
+                        protocol = URLProtocol.HTTPS
+                        host = validateHost
+                        path(path)
+                        parameters.append("secret", secretKey)
+                        parameters.append("response", token)
+                    }
+                }
+            } catch (io: IOException) {
+                throw RecaptchaIOError(io)
+            }
+
+        val status = response.status
+        if (status.value !in 200..299)
+            throw UnexpectedError("Invalid respond status code: ${status.value}, ${status.description}", null)
+
+        val body = try {
+            JsonParser.parseString(response.bodyAsText())
+        } catch (syntax: JsonSyntaxException) {
+            throw UnableToDeserializeError(syntax)
+        }
+
+        if (!body.isJsonObject)
+            throw UnexpectedJsonStructure("response json isn't an object")
+        return body.asJsonObject
+    }
+
+    override fun close() = client.close()
+
+}

--- a/src/main/kotlin/com/wusatosi/recaptcha/internal/RecaptchaClientBase.kt
+++ b/src/main/kotlin/com/wusatosi/recaptcha/internal/RecaptchaClientBase.kt
@@ -1,16 +1,15 @@
 package com.wusatosi.recaptcha.internal
 
 import com.google.gson.JsonObject
+import com.google.gson.JsonParseException
 import com.google.gson.JsonParser
 import com.google.gson.JsonSyntaxException
 import com.wusatosi.recaptcha.*
 import io.ktor.client.*
 import io.ktor.client.engine.*
-import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-import io.ktor.serialization.gson.*
 import java.io.IOException
 
 internal abstract class RecaptchaClientBase(
@@ -19,11 +18,7 @@ internal abstract class RecaptchaClientBase(
     engine: HttpClientEngine
 ) : RecaptchaClient {
 
-    protected val client: HttpClient = HttpClient(engine) {
-        install(ContentNegotiation) {
-            gson()
-        }
-    }
+    protected val client: HttpClient = HttpClient(engine) {}
     private val validateHost = if (useRecaptchaDotNetEndPoint) "www.recaptcha.net" else "www.google.com"
     private val path = "/recaptcha/api/siteverify"
 
@@ -57,7 +52,7 @@ internal abstract class RecaptchaClientBase(
         }
 
         if (!body.isJsonObject)
-            throw UnexpectedJsonStructure("response json isn't an object")
+            throw UnableToDeserializeError(JsonParseException("expected object"))
         return body.asJsonObject
     }
 

--- a/src/main/kotlin/com/wusatosi/recaptcha/internal/RecaptchaV2ClientImpl.kt
+++ b/src/main/kotlin/com/wusatosi/recaptcha/internal/RecaptchaV2ClientImpl.kt
@@ -1,15 +1,13 @@
 package com.wusatosi.recaptcha.internal
 
 import com.wusatosi.recaptcha.v2.RecaptchaV2Client
+import io.ktor.client.engine.*
 
 internal class RecaptchaV2ClientImpl(
     secretKey: String,
-    useRecaptchaDotNetEndPoint: Boolean = false
-) : RecaptchaV2Client {
-
-    private val validateURL = "https://" +
-            (if (useRecaptchaDotNetEndPoint) "www.recaptcha.net" else "www.google.com") +
-            "/recaptcha/api/siteverify?secret=$secretKey&response="
+    useRecaptchaDotNetEndPoint: Boolean,
+    engine: HttpClientEngine
+) : RecaptchaClientBase(secretKey, useRecaptchaDotNetEndPoint, engine), RecaptchaV2Client {
 
     override suspend fun verify(token: String): Boolean {
 //        There is no way to validate it here,

--- a/src/main/kotlin/com/wusatosi/recaptcha/internal/RecaptchaV2ClientImpl.kt
+++ b/src/main/kotlin/com/wusatosi/recaptcha/internal/RecaptchaV2ClientImpl.kt
@@ -16,7 +16,7 @@ internal class RecaptchaV2ClientImpl(
         if (!checkURLCompatibility(token))
             return false
 
-        val obj = getJsonObj(validateURL, token)
+        val obj = transact(token)
 
         val isSuccess = obj["success"]
             .expectPrimitive("success")

--- a/src/main/kotlin/com/wusatosi/recaptcha/internal/RecaptchaV3ClientImpl.kt
+++ b/src/main/kotlin/com/wusatosi/recaptcha/internal/RecaptchaV3ClientImpl.kt
@@ -1,16 +1,14 @@
 package com.wusatosi.recaptcha.internal
 
 import com.wusatosi.recaptcha.v3.RecaptchaV3Client
+import io.ktor.client.engine.*
 
 internal class RecaptchaV3ClientImpl(
     secretKey: String,
-    private val defaultScoreThreshold: Double = 0.5,
-    useRecaptchaDotNetEndPoint: Boolean = false
-) : RecaptchaV3Client {
-
-    private val validateURL = "https://" +
-            (if (useRecaptchaDotNetEndPoint) "www.recaptcha.net" else "www.google.com") +
-            "/recaptcha/api/siteverify?secret=$secretKey&response="
+    private val defaultScoreThreshold: Double,
+    useRecaptchaDotNetEndPoint: Boolean,
+    engine: HttpClientEngine
+) : RecaptchaClientBase(secretKey, useRecaptchaDotNetEndPoint, engine), RecaptchaV3Client {
 
     override suspend fun getVerifyScore(
         token: String,
@@ -22,7 +20,7 @@ internal class RecaptchaV3ClientImpl(
 //        that is valid for a URL string
         if (!checkURLCompatibility(token)) return invalidate_token_score
 
-        val obj = getJsonObj(validateURL, token)
+        val obj = getJsonObj("validateURL", token)
 
         val isSuccess = obj["success"]
             .expectPrimitive("success")

--- a/src/main/kotlin/com/wusatosi/recaptcha/internal/RecaptchaV3ClientImpl.kt
+++ b/src/main/kotlin/com/wusatosi/recaptcha/internal/RecaptchaV3ClientImpl.kt
@@ -20,7 +20,7 @@ internal class RecaptchaV3ClientImpl(
 //        that is valid for a URL string
         if (!checkURLCompatibility(token)) return invalidate_token_score
 
-        val obj = getJsonObj("validateURL", token)
+        val obj = transact(token)
 
         val isSuccess = obj["success"]
             .expectPrimitive("success")

--- a/src/main/kotlin/com/wusatosi/recaptcha/internal/UniversalRecaptchaClientImpl.kt
+++ b/src/main/kotlin/com/wusatosi/recaptcha/internal/UniversalRecaptchaClientImpl.kt
@@ -14,7 +14,7 @@ internal class UniversalRecaptchaClientImpl(
         if (!checkURLCompatibility(token))
             return false
 
-        val obj = getJsonObj(validateURL, token)
+        val obj = transact(token)
 
         val isSuccess = obj["success"]
             .expectBoolean("success")

--- a/src/main/kotlin/com/wusatosi/recaptcha/internal/UniversalRecaptchaClientImpl.kt
+++ b/src/main/kotlin/com/wusatosi/recaptcha/internal/UniversalRecaptchaClientImpl.kt
@@ -1,16 +1,14 @@
 package com.wusatosi.recaptcha.internal
 
 import com.wusatosi.recaptcha.RecaptchaClient
+import io.ktor.client.engine.*
 
 internal class UniversalRecaptchaClientImpl(
     secretKey: String,
-    private val defaultScoreThreshold: Double = 0.5,
-    useRecaptchaDotNetEndPoint: Boolean = false
-) : RecaptchaClient {
-
-    private val validateURL = "https://" +
-            (if (useRecaptchaDotNetEndPoint) "www.recaptcha.net" else "www.google.com") +
-            "/recaptcha/api/siteverify?secret=$secretKey&response="
+    private val defaultScoreThreshold: Double,
+    useRecaptchaDotNetEndPoint: Boolean,
+    engine: HttpClientEngine
+) : RecaptchaClientBase(secretKey, useRecaptchaDotNetEndPoint, engine), RecaptchaClient {
 
     override suspend fun verify(token: String): Boolean {
         if (!checkURLCompatibility(token))

--- a/src/main/kotlin/com/wusatosi/recaptcha/v2/RecaptchaV2Client.kt
+++ b/src/main/kotlin/com/wusatosi/recaptcha/v2/RecaptchaV2Client.kt
@@ -4,16 +4,23 @@ import com.wusatosi.recaptcha.InvalidSiteKeyException
 import com.wusatosi.recaptcha.RecaptchaClient
 import com.wusatosi.recaptcha.internal.RecaptchaV2ClientImpl
 import com.wusatosi.recaptcha.internal.checkURLCompatibility
+import io.ktor.client.engine.*
+import io.ktor.client.engine.cio.*
 
 interface RecaptchaV2Client : RecaptchaClient {
 
     companion object {
-        fun create(siteKey: String, useRecaptchaDotNetEndPoint: Boolean = false): RecaptchaV2Client {
+        fun create(
+            siteKey: String,
+            useRecaptchaDotNetEndPoint: Boolean = false,
+            engine: HttpClientEngine = CIO.create()
+        ): RecaptchaV2Client {
             if (!checkURLCompatibility(siteKey))
                 throw InvalidSiteKeyException
             return RecaptchaV2ClientImpl(
                 siteKey,
-                useRecaptchaDotNetEndPoint
+                useRecaptchaDotNetEndPoint,
+                engine
             )
         }
     }

--- a/src/main/kotlin/com/wusatosi/recaptcha/v3/RecaptchaV3Client.kt
+++ b/src/main/kotlin/com/wusatosi/recaptcha/v3/RecaptchaV3Client.kt
@@ -4,6 +4,8 @@ import com.wusatosi.recaptcha.InvalidSiteKeyException
 import com.wusatosi.recaptcha.RecaptchaClient
 import com.wusatosi.recaptcha.internal.RecaptchaV3ClientImpl
 import com.wusatosi.recaptcha.internal.checkURLCompatibility
+import io.ktor.client.engine.*
+import io.ktor.client.engine.cio.*
 
 interface RecaptchaV3Client : RecaptchaClient {
 
@@ -17,14 +19,16 @@ interface RecaptchaV3Client : RecaptchaClient {
         fun create(
             secretKey: String,
             defaultScoreThreshold: Double = 0.5,
-            useRecaptchaDotNetEndPoint: Boolean = false
+            useRecaptchaDotNetEndPoint: Boolean = false,
+            engine: HttpClientEngine = CIO.create()
         ): RecaptchaV3Client {
             if (!checkURLCompatibility(secretKey))
                 throw InvalidSiteKeyException
             return RecaptchaV3ClientImpl(
                 secretKey,
                 defaultScoreThreshold,
-                useRecaptchaDotNetEndPoint
+                useRecaptchaDotNetEndPoint,
+                engine
             )
         }
     }

--- a/src/test/kotlin/com/wusatosi/recaptcha/internal/RecaptchaClientBaseTest.kt
+++ b/src/test/kotlin/com/wusatosi/recaptcha/internal/RecaptchaClientBaseTest.kt
@@ -48,10 +48,10 @@ class RecaptchaClientBaseTest {
             val token = "token"
 
             val mockEngine = MockEngine {
-                assertEquals(it.url.host, "www.google.com")
-                assertEquals(it.url.encodedPath, "/recaptcha/api/siteverify")
-                assertEquals(it.url.encodedQuery, "secret=$siteKey&response=$token")
-                assertEquals(it.method, HttpMethod.Post)
+                assertEquals("www.google.com", it.url.host)
+                assertEquals("/recaptcha/api/siteverify", it.url.encodedPath)
+                assertEquals("secret=$siteKey&response=$token", it.url.encodedQuery)
+                assertEquals(HttpMethod.Post, it.method)
                 respondOk("{}")
             }
 

--- a/src/test/kotlin/com/wusatosi/recaptcha/internal/RecaptchaClientBaseTest.kt
+++ b/src/test/kotlin/com/wusatosi/recaptcha/internal/RecaptchaClientBaseTest.kt
@@ -1,0 +1,127 @@
+package com.wusatosi.recaptcha.internal
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser.parseString
+import com.wusatosi.recaptcha.RecaptchaIOError
+import com.wusatosi.recaptcha.UnableToDeserializeError
+import com.wusatosi.recaptcha.UnexpectedError
+import io.ktor.client.engine.*
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.IOException
+
+class RecaptchaClientBaseTest {
+
+    private suspend fun simulate(
+        engine: HttpClientEngine,
+        siteKey: String = "key",
+        token: String = "token",
+        useRecaptchaDotNetEndPoint: Boolean = false
+    ): JsonObject? {
+        var result: JsonObject? = null
+
+        class Subject(
+            engine: HttpClientEngine,
+            siteKey: String,
+            useRecaptchaDotNetEndPoint: Boolean,
+        ) :
+            RecaptchaClientBase(siteKey, useRecaptchaDotNetEndPoint, engine) {
+            override suspend fun verify(token: String): Boolean {
+                result = transact(token)
+                return true
+            }
+        }
+
+        Subject(engine, siteKey, useRecaptchaDotNetEndPoint).use { it.verify(token) }
+        return result
+    }
+
+
+    @Test
+    fun properParameters() =
+        runBlocking<Unit> {
+            val siteKey = "key"
+            val token = "token"
+
+            val mockEngine = MockEngine {
+                assertEquals(it.url.host, "www.google.com")
+                assertEquals(it.url.encodedPath, "/recaptcha/api/siteverify")
+                assertEquals(it.url.encodedQuery, "secret=$siteKey&response=$token")
+                assertEquals(it.method, HttpMethod.Post)
+                respondOk("{}")
+            }
+
+            simulate(mockEngine, siteKey, token)
+        }
+
+    @Test
+    fun correctParsing() = runBlocking {
+        val exampleReturn = """
+            {"success":true,"challenge_ts":"2023-03-28T22:10:10Z","hostname":"wusatosi.com"}
+        """.trimIndent()
+        val mockEngine = MockEngine {
+            respondOk(exampleReturn)
+        }
+        assertEquals(parseString(exampleReturn), simulate(mockEngine))
+    }
+
+    @Test
+    fun switchDomain() =
+        runBlocking<Unit> {
+            val mockEngine = MockEngine {
+                assertEquals(it.url.host, "www.recaptcha.net")
+                respondOk("{}")
+            }
+            simulate(mockEngine, useRecaptchaDotNetEndPoint = true)
+        }
+
+    @Test
+    fun ioExceptionUponRequest() =
+        runBlocking<Unit> {
+            val mockEngine = MockEngine {
+                throw IOException("boom!")
+            }
+            assertThrows<RecaptchaIOError> { simulate(mockEngine) }
+        }
+
+    @Test
+    fun badStatus() =
+        runBlocking<Unit> {
+            val mockEngine = MockEngine {
+                respondBadRequest()
+            }
+            assertThrows<UnexpectedError> { simulate(mockEngine) }
+        }
+
+    @Test
+    fun badStatus2() =
+        runBlocking<Unit> {
+            val mockEngine = MockEngine {
+                respondError(HttpStatusCode.InternalServerError)
+            }
+            assertThrows<UnexpectedError> { simulate(mockEngine) }
+        }
+
+    @Test
+    fun malformedResponse() =
+        runBlocking<Unit> {
+            val mockEngine = MockEngine {
+                respondOk("{abcdefg")
+            }
+            assertThrows<UnableToDeserializeError> { simulate(mockEngine) }
+        }
+
+    @Test
+    fun malformedResponse2() =
+        runBlocking<Unit> {
+            val mockEngine = MockEngine {
+                respondOk("abcdefg")
+            }
+            assertThrows<UnableToDeserializeError> { simulate(mockEngine) }
+        }
+
+}


### PR DESCRIPTION
This pr switches from [Fuel](https://fuel.gitbook.io/documentation/) to [Ktor](https://ktor.io/docs/welcome.html) as Ktor is more actively maintained and its testing framework is better.

However, this does require the client to be closeable.